### PR TITLE
Phoenix 1.3 support

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule PhoenixMjml.Mixfile do
   end
 
   defp deps do
-    [{:phoenix, "~> 1.2.0"},
+    [{:phoenix, "~> 1.2.0 or ~>1.3.0"},
      {:phoenix_html, "~> 2.6"},
      {:uuid, "~> 1.1"},
      {:ex_doc, "~> 0.14", only: :dev, runtime: false}]


### PR DESCRIPTION

I want to use in my phoenix 1.3 project however dependencies could not be resolved without updating phoenix_mjml's mix.exs. 

Phoenix 1.3 is pretty stable now, and I notice there are more than one forks that merely update mix.exs to support 1.3. 